### PR TITLE
Set extensionKind to "ui" for remoting support

### DIFF
--- a/package.json
+++ b/package.json
@@ -582,5 +582,6 @@
 	},
 	"dependencies": {
 		"lodash": "^4.17.20"
-	}
+	},
+	"extensionKind": ["ui"]
 }


### PR DESCRIPTION
Sets the `extensionKind` to `ui` to allow the extension to be used in remote development environments. This forces the extension to run as a UI extension (on the local machine) rather than a workspace extension (on the remote machine).

Reference: https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location