### PR TITLE
Change extensionKind to workspace only

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
 		"npm": ">=7.0.0"
 	},
 	"extensionKind": [
-		"ui",
 		"workspace"
 	],
 	"categories": [


### PR DESCRIPTION
In the latest version of vs code insiders globally active extensions
running on the remote are not receiving
`languages.onDidChangeDiagnostics` correctly from the remote. Changing
`extensionKind` to `workspace` force the need from installation on
remote and will receive the events correctly.

Fixes #103

Signed-off-by: Matheus Castello <matheus@castello.eng.br>