### PR TITLE
feat: Excluding workspaces feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,6 +355,14 @@
 					},
 					"markdownDescription": "Exclude files by using glob pattern. Example `[\"**/*.{ts,js}\"]`"
 				},
+				"errorLens.excludeWorkspaces": {
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "Exclude workspaces by workspace path"
+				},
 				"errorLens.light": {
 					"type": "object",
 					"description": "Specify color of decorations for when the light color theme is active.",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
 				"title": "Copy Problem Message",
 				"description": "Copy problem message to the clipboard (at the active cursor).",
 				"category": "Error Lens"
+			},
+			{
+				"command": "errorlens.toggleWorkspace",
+				"title": "Toggle Workspace in Disabled List",
+				"description": "Exclude/Include current workspace from Error Lens",
+				"category": "Error Lens"
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"onCommand:errorLens.toggleWarning",
 		"onCommand:errorLens.toggleInfo",
 		"onCommand:errorLens.toggleHint",
-		"onCommand:errorLens.copyProblemMessage"
+		"onCommand:errorLens.copyProblemMessage",
+		"onCommand:errorLens.toggleWorkspace"
 	],
 	"main": "./dist/extension.js",
 	"browser": "./dist/extension.js",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { $config, Global } from 'src/extension';
-import { toggleEnabledLevels, updateGlobalSetting } from 'src/settings';
+import { toggleEnabledLevels, toggleWorkspace, updateGlobalSetting } from 'src/settings';
 import { AggregatedByLineDiagnostics, CommandId, Constants } from 'src/types';
 import { commands, env, ExtensionContext, languages, Range, Selection, TextEditorRevealType, window, workspace } from 'vscode';
 
@@ -21,6 +21,9 @@ export function registerAllCommands(extensionContext: ExtensionContext) {
 	});
 	const disposableToggleHint = commands.registerCommand(CommandId.toggleHint, () => {
 		toggleEnabledLevels('hint', $config.enabledDiagnosticLevels);
+	});
+	const disposableToggleWorkspace = commands.registerCommand(CommandId.toggleWorkspace, () => {
+		toggleWorkspace();
 	});
 
 	const disposableCopyProblemMessage = commands.registerTextEditorCommand(CommandId.copyProblemMessage, editor => {

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -2,7 +2,7 @@ import { $config, Global } from 'src/extension';
 import { doUpdateGutterDecorations, getGutterStyles } from 'src/gutter';
 import { AggregatedByLineDiagnostics, Constants } from 'src/types';
 import { replaceLinebreaks, truncateString } from 'src/utils';
-import { DecorationInstanceRenderOptions, DecorationOptions, DecorationRenderOptions, Diagnostic, ExtensionContext, languages, Range, TextEditor, ThemableDecorationAttachmentRenderOptions, ThemeColor, Uri, window } from 'vscode';
+import { DecorationInstanceRenderOptions, DecorationOptions, DecorationRenderOptions, Diagnostic, ExtensionContext, languages, Range, TextEditor, ThemableDecorationAttachmentRenderOptions, ThemeColor, Uri, window, workspace } from 'vscode';
 
 /**
  * Update all decoration styles: editor, gutter, status bar
@@ -337,6 +337,12 @@ export function doUpdateDecorations(editor: TextEditor, aggregatedDiagnostics: A
 
 export function updateDecorationsForAllVisibleEditors() {
 	for (const editor of window.visibleTextEditors) {
+		const excludeWorkspaces = $config.excludeWorkspaces;
+		const currentWorkspacePath = workspace.getWorkspaceFolder(editor.document.uri)?.uri.path;
+		if (currentWorkspacePath && excludeWorkspaces.includes(currentWorkspacePath)) {
+			continue;
+		}
+
 		updateDecorationsForUri(editor.document.uri, editor);
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { ExtensionConfig } from 'src/types';
-import { ConfigurationTarget, workspace } from 'vscode';
+import { ConfigurationTarget, window, workspace } from 'vscode';
+import { $config } from './extension';
 
 /**
  * Update global settings.json file with the new settign value.
@@ -23,4 +24,29 @@ export function toggleEnabledLevels(
 		arrayValue.push(severity);
 	}
 	updateGlobalSetting('errorLens.enabledDiagnosticLevels', arrayValue);
+}
+
+export function toggleWorkspace(): void {
+	const activeEditor = window.activeTextEditor;
+	const config = $config;
+
+	if (!activeEditor) {
+		return;
+	}
+
+	const currentWorkspacePath = workspace.getWorkspaceFolder(activeEditor.document.uri)?.uri.path;
+
+	if (!currentWorkspacePath) {
+		return;
+	}
+
+	let newExcludeWorkspaceList: string[];
+
+	if (config.excludeWorkspaces?.includes(currentWorkspacePath)) {
+		newExcludeWorkspaceList = config.excludeWorkspaces.filter(workspacePath => workspacePath !== currentWorkspacePath);
+	} else {
+		newExcludeWorkspaceList = [...(config.excludeWorkspaces || []), currentWorkspacePath];
+	}
+
+	updateGlobalSetting('errorLens.excludeWorkspaces', newExcludeWorkspaceList);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,7 @@ export const enum CommandId {
 	toggleWarning = 'errorLens.toggleWarning',
 	toggleInfo = 'errorLens.toggleInfo',
 	toggleHint = 'errorLens.toggleHint',
+	toggleWorkspace = 'errorlens.toggleWorkspace',
 	copyProblemMessage = 'errorLens.copyProblemMessage',
 	statusBarCommand = 'errorLens.statusBarCommand',
 	revealLine = 'errorLens.revealLine',

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,11 @@ interface ExtensionConfigType {
 		warningGutterIconColor: string;
 		infoGutterIconColor: string;
 	};
+
+	/**
+	 * Disable highlighting for selected workspaces
+	 */
+	excludeWorkspaces: string[];
 }
 
 export type ExtensionConfig = Readonly<ExtensionConfigType>;


### PR DESCRIPTION
Hello,

I'm excited to submit this PR for the errorLens extension! As a user of the extension myself, I noticed that it can be distracting to have error messages from all open workspaces displayed at once. To address this, I've added a new feature that allows users to exclude specific workspaces from being decorated with error messages.

With this new feature, users can focus on the task at hand without being distracted by errors from other projects. The excludeWorkspaces configuration option accepts an array of workspace paths to exclude, making it easy to customize the extension to fit individual workflows.

In addition, I've also added a new command to the extension that allows users to toggle the current workspace's inclusion in the excludeWorkspaces list.

Overall, I believe that this PR will make the errorLens extension more flexible and user-friendly. Thank you for considering my contribution!