### PR TITLE
feat: add 'replace' config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -385,6 +385,24 @@
 					"default": "",
 					"markdownDescription": "Template for status bar message. Whitespace between items is important.\n\nList of variables:\n\n- `$message` - diagnostic message text\n\n- `$count` - Number of diagnostics on the line\n\n- `$severity` - Severity prefix taken from `#errorLens.severityText#`\n\n- `$source` - Source of diagnostic e.g. \"eslint\"\n\n- `$code` - Code of the diagnostic"
 				},
+				"errorLens.replace": {
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "object",
+						"properties": {
+							"matcher": {
+								"type": "string",
+								"description": "The RegExp pattern against which to match diagnostic messages"
+							},
+							"message": {
+								"type": "string",
+								"description": "The entire replacement for messages matching matcher. Can reference match groups like $0 (entire expression), $1 (first capture group), etc."
+							} 
+						}
+					},
+					"markdownDescription": "Specify message to transform. E.g. if this is configured to [{ matcher: 'foo (.*)', message: 'just $1' }], the message 'foo bar' would be displayed as 'just bar'."
+				},
 				"errorLens.exclude": {
 					"type": "array",
 					"default": [],

--- a/package.json
+++ b/package.json
@@ -399,7 +399,8 @@
 								"type": "string",
 								"description": "The entire replacement for messages matching matcher. Can reference match groups like $0 (entire expression), $1 (first capture group), etc."
 							} 
-						}
+						},
+						"required": ["matcher", "message"]
 					},
 					"markdownDescription": "Specify message to transform. E.g. if this is configured to [{ matcher: 'foo (.*)', message: 'just $1' }], the message 'foo bar' would be displayed as 'just bar'."
 				},

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,21 @@ interface ExtensionConfigType {
 	 */
 	severityText: string[];
 	/**
+	 * Array of objects with a "pattern" that matches a `Diagnostic.message` and a "message" that transforms it.
+	 * Captured groups from the match are available in "message" as $0, $1 etc.
+	 * Applies before the message is added to the template.
+	 * 
+	 * Example usage:
+	 * 
+	 * Original message: "foo bar"
+	 * Config: [{ matcher: "foo (.*)", message: "just $1" }]
+	 * Transformed message: "just bar"
+	 */
+	replace: {
+		matcher: string;
+		message: string;
+	}[];
+	/**
 	 * Array of diagnostic messages that should not be decorated. Matches against `Diagnostic.message`.
 	 */
 	exclude: string[];


### PR DESCRIPTION
This adds a config option to flexibly allow regex-based transformations of diagnostic messages. E.g. the following config:

```json
{
    "errorLens.replace": [
        {
            "matcher": "foo (.*)",
            "message": "just $1"
        }
    ]
}
```

Would transform a diagnostic message `"foo bar"` to `"just bar"`.