### PR TITLE
Add a command to select problem in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
 				"category": "Error Lens"
 			},
 			{
+				"command": "errorLens.selectProblem",
+				"title": "Select Problem",
+				"description": "Set editor selection to the problem range (at the active cursor).",
+				"category": "Error Lens"
+			},
+			{
 				"command": "errorLens.findLinterRuleDefinition",
 				"title": "Find Linter Rule Definition",
 				"description": "Search in local linter files (like `.eslintrc.json`) for the rule definition.",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,85 +1,100 @@
-import { copyProblemCodeCommand } from 'src/commands/copyProblemCodeCommand';
-import { copyProblemMessageCommand } from 'src/commands/copyProblemMessageCommand';
-import { disableLineCommand } from 'src/commands/disableLineCommand';
-import { excludeProblemCommand } from 'src/commands/excludeProblemCommand';
-import { findLinterRuleDefinitionCommand } from 'src/commands/findLinterRuleDefinitionCommand';
-import { revealLineCommand } from 'src/commands/revealLineCommand';
-import { searchForProblemCommand } from 'src/commands/searchForProblemCommand';
-import { statusBarCommand } from 'src/commands/statusBarCommand';
-import { toggleEnabledLevels } from 'src/commands/toggleEnabledLevels';
-import { toggleWorkspaceCommand } from 'src/commands/toggleWorkspaceCommand';
-import { $config } from 'src/extension';
-import { vscodeUtils } from 'src/utils/vscodeUtils';
-import { commands, type ExtensionContext } from 'vscode';
+import { copyProblemCodeCommand } from 'src/commands/copyProblemCodeCommand'
+import { copyProblemMessageCommand } from 'src/commands/copyProblemMessageCommand'
+import { disableLineCommand } from 'src/commands/disableLineCommand'
+import { excludeProblemCommand } from 'src/commands/excludeProblemCommand'
+import { findLinterRuleDefinitionCommand } from 'src/commands/findLinterRuleDefinitionCommand'
+import { revealLineCommand } from 'src/commands/revealLineCommand'
+import { searchForProblemCommand } from 'src/commands/searchForProblemCommand'
+import { selectProblem } from 'src/commands/selectProblem'
+import { statusBarCommand } from 'src/commands/statusBarCommand'
+import { toggleEnabledLevels } from 'src/commands/toggleEnabledLevels'
+import { toggleWorkspaceCommand } from 'src/commands/toggleWorkspaceCommand'
+import { $config } from 'src/extension'
+import { vscodeUtils } from 'src/utils/vscodeUtils'
+import { commands, type ExtensionContext } from 'vscode'
 
 /**
  * All command ids contributed by this extensions.
  */
 export const enum CommandId {
-	// ──── User facing ───────────────────────────────────────────
-	Toggle = 'errorLens.toggle',
-	ToggleError = 'errorLens.toggleError',
-	ToggleWarning = 'errorLens.toggleWarning',
-	ToggleInfo = 'errorLens.toggleInfo',
-	ToggleHint = 'errorLens.toggleHint',
-	ToggleInlineMessage = 'errorLens.toggleInlineMessage',
-	/** {@link toggleWorkspaceCommand} */
-	ToggleWorkspace = 'errorlens.toggleWorkspace',
-	/** {@link copyProblemMessageCommand} */
-	CopyProblemMessage = 'errorLens.copyProblemMessage',
-	/** {@link copyProblemCodeCommand} */
-	CopyProblemCode = 'errorLens.copyProblemCode',
-	/** {@link findLinterRuleDefinitionCommand} */
-	FindLinterRuleDefinition = 'errorLens.findLinterRuleDefinition',
-	/** {@link searchForProblemCommand} */
-	SearchForProblem = 'errorLens.searchForProblem',
-	/** {@link disableLineCommand} */
-	DisableLine = 'errorLens.disableLine',
-	// ──── Internal ──────────────────────────────────────────────
-	/** {@link statusBarCommand} */
-	StatusBarCommand = 'errorLens.statusBarCommand',
-	/** {@link revealLineCommand} */
-	RevealLine = 'errorLens.revealLine',
-	/** {@link excludeProblemCommand} */
-	ExcludeProblem = 'errorLens.excludeProblem',
+    // ──── User facing ───────────────────────────────────────────
+    Toggle = 'errorLens.toggle',
+    ToggleError = 'errorLens.toggleError',
+    ToggleWarning = 'errorLens.toggleWarning',
+    ToggleInfo = 'errorLens.toggleInfo',
+    ToggleHint = 'errorLens.toggleHint',
+    ToggleInlineMessage = 'errorLens.toggleInlineMessage',
+    /** {@link toggleWorkspaceCommand} */
+    ToggleWorkspace = 'errorlens.toggleWorkspace',
+    /** {@link copyProblemMessageCommand} */
+    CopyProblemMessage = 'errorLens.copyProblemMessage',
+    /** {@link copyProblemCodeCommand} */
+    CopyProblemCode = 'errorLens.copyProblemCode',
+    /** {@link selectProblem} */
+    SelectProblem = 'errorLens.selectProblem',
+    /** {@link findLinterRuleDefinitionCommand} */
+    FindLinterRuleDefinition = 'errorLens.findLinterRuleDefinition',
+    /** {@link searchForProblemCommand} */
+    SearchForProblem = 'errorLens.searchForProblem',
+    /** {@link disableLineCommand} */
+    DisableLine = 'errorLens.disableLine',
+    // ──── Internal ──────────────────────────────────────────────
+    /** {@link statusBarCommand} */
+    StatusBarCommand = 'errorLens.statusBarCommand',
+    /** {@link revealLineCommand} */
+    RevealLine = 'errorLens.revealLine',
+    /** {@link excludeProblemCommand} */
+    ExcludeProblem = 'errorLens.excludeProblem',
 }
 
 /**
  * Register all commands contributed by this extension.
  */
 export function registerAllCommands(context: ExtensionContext): void {
-	// ────────────────────────────────────────────────────────────
-	// ──── Global commands ───────────────────────────────────────
-	// ────────────────────────────────────────────────────────────
-	context.subscriptions.push(commands.registerCommand(CommandId.Toggle, () => {
-		vscodeUtils.updateGlobalSetting('errorLens.enabled', !$config.enabled);
-	}));
-	context.subscriptions.push(commands.registerCommand(CommandId.ToggleError, () => {
-		toggleEnabledLevels('error', $config.enabledDiagnosticLevels);
-	}));
-	context.subscriptions.push(commands.registerCommand(CommandId.ToggleWarning, () => {
-		toggleEnabledLevels('warning', $config.enabledDiagnosticLevels);
-	}));
-	context.subscriptions.push(commands.registerCommand(CommandId.ToggleInfo, () => {
-		toggleEnabledLevels('info', $config.enabledDiagnosticLevels);
-	}));
-	context.subscriptions.push(commands.registerCommand(CommandId.ToggleHint, () => {
-		toggleEnabledLevels('hint', $config.enabledDiagnosticLevels);
-	}));
-	context.subscriptions.push(commands.registerCommand(CommandId.ToggleInlineMessage, () => {
-		vscodeUtils.toggleGlobalBooleanSetting('errorLens.messageEnabled');
-	}));
-	context.subscriptions.push(commands.registerCommand(CommandId.ToggleWorkspace, toggleWorkspaceCommand));
-	context.subscriptions.push(commands.registerCommand(CommandId.RevealLine, revealLineCommand));
-	context.subscriptions.push(commands.registerCommand(CommandId.FindLinterRuleDefinition, findLinterRuleDefinitionCommand));
-	context.subscriptions.push(commands.registerCommand(CommandId.ExcludeProblem, excludeProblemCommand));
-	context.subscriptions.push(commands.registerCommand(CommandId.CopyProblemCode, copyProblemCodeCommand));
-	context.subscriptions.push(commands.registerCommand(CommandId.SearchForProblem, searchForProblemCommand));
-	context.subscriptions.push(commands.registerCommand(CommandId.DisableLine, disableLineCommand));
-	// ────────────────────────────────────────────────────────────
-	// ──── Text Editor commands ──────────────────────────────────
-	// ────────────────────────────────────────────────────────────
-	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.CopyProblemMessage, copyProblemMessageCommand));
-	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.StatusBarCommand, statusBarCommand));
+    // ────────────────────────────────────────────────────────────
+    // ──── Global commands ───────────────────────────────────────
+    // ────────────────────────────────────────────────────────────
+    context.subscriptions.push(
+        commands.registerCommand(CommandId.Toggle, () => {
+            vscodeUtils.updateGlobalSetting('errorLens.enabled', !$config.enabled)
+        }),
+    )
+    context.subscriptions.push(
+        commands.registerCommand(CommandId.ToggleError, () => {
+            toggleEnabledLevels('error', $config.enabledDiagnosticLevels)
+        }),
+    )
+    context.subscriptions.push(
+        commands.registerCommand(CommandId.ToggleWarning, () => {
+            toggleEnabledLevels('warning', $config.enabledDiagnosticLevels)
+        }),
+    )
+    context.subscriptions.push(
+        commands.registerCommand(CommandId.ToggleInfo, () => {
+            toggleEnabledLevels('info', $config.enabledDiagnosticLevels)
+        }),
+    )
+    context.subscriptions.push(
+        commands.registerCommand(CommandId.ToggleHint, () => {
+            toggleEnabledLevels('hint', $config.enabledDiagnosticLevels)
+        }),
+    )
+    context.subscriptions.push(
+        commands.registerCommand(CommandId.ToggleInlineMessage, () => {
+            vscodeUtils.toggleGlobalBooleanSetting('errorLens.messageEnabled')
+        }),
+    )
+    context.subscriptions.push(commands.registerCommand(CommandId.ToggleWorkspace, toggleWorkspaceCommand))
+    context.subscriptions.push(commands.registerCommand(CommandId.RevealLine, revealLineCommand))
+    context.subscriptions.push(commands.registerCommand(CommandId.FindLinterRuleDefinition, findLinterRuleDefinitionCommand))
+    context.subscriptions.push(commands.registerCommand(CommandId.ExcludeProblem, excludeProblemCommand))
+    context.subscriptions.push(commands.registerCommand(CommandId.CopyProblemCode, copyProblemCodeCommand))
+    context.subscriptions.push(commands.registerCommand(CommandId.SearchForProblem, searchForProblemCommand))
+    context.subscriptions.push(commands.registerCommand(CommandId.DisableLine, disableLineCommand))
+    // ────────────────────────────────────────────────────────────
+    // ──── Text Editor commands ──────────────────────────────────
+    // ────────────────────────────────────────────────────────────
+    context.subscriptions.push(commands.registerTextEditorCommand(CommandId.SelectProblem, selectProblem))
+    context.subscriptions.push(commands.registerTextEditorCommand(CommandId.CopyProblemMessage, copyProblemMessageCommand))
+    context.subscriptions.push(commands.registerTextEditorCommand(CommandId.StatusBarCommand, statusBarCommand))
 }
-

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,100 +1,100 @@
-import { copyProblemCodeCommand } from 'src/commands/copyProblemCodeCommand'
-import { copyProblemMessageCommand } from 'src/commands/copyProblemMessageCommand'
-import { disableLineCommand } from 'src/commands/disableLineCommand'
-import { excludeProblemCommand } from 'src/commands/excludeProblemCommand'
-import { findLinterRuleDefinitionCommand } from 'src/commands/findLinterRuleDefinitionCommand'
-import { revealLineCommand } from 'src/commands/revealLineCommand'
-import { searchForProblemCommand } from 'src/commands/searchForProblemCommand'
-import { selectProblem } from 'src/commands/selectProblem'
-import { statusBarCommand } from 'src/commands/statusBarCommand'
-import { toggleEnabledLevels } from 'src/commands/toggleEnabledLevels'
-import { toggleWorkspaceCommand } from 'src/commands/toggleWorkspaceCommand'
-import { $config } from 'src/extension'
-import { vscodeUtils } from 'src/utils/vscodeUtils'
-import { commands, type ExtensionContext } from 'vscode'
+import { copyProblemCodeCommand } from 'src/commands/copyProblemCodeCommand';
+import { copyProblemMessageCommand } from 'src/commands/copyProblemMessageCommand';
+import { disableLineCommand } from 'src/commands/disableLineCommand';
+import { excludeProblemCommand } from 'src/commands/excludeProblemCommand';
+import { findLinterRuleDefinitionCommand } from 'src/commands/findLinterRuleDefinitionCommand';
+import { revealLineCommand } from 'src/commands/revealLineCommand';
+import { searchForProblemCommand } from 'src/commands/searchForProblemCommand';
+import { selectProblem } from 'src/commands/selectProblem';
+import { statusBarCommand } from 'src/commands/statusBarCommand';
+import { toggleEnabledLevels } from 'src/commands/toggleEnabledLevels';
+import { toggleWorkspaceCommand } from 'src/commands/toggleWorkspaceCommand';
+import { $config } from 'src/extension';
+import { vscodeUtils } from 'src/utils/vscodeUtils';
+import { commands, type ExtensionContext } from 'vscode';
 
 /**
  * All command ids contributed by this extensions.
  */
 export const enum CommandId {
-    // ──── User facing ───────────────────────────────────────────
-    Toggle = 'errorLens.toggle',
-    ToggleError = 'errorLens.toggleError',
-    ToggleWarning = 'errorLens.toggleWarning',
-    ToggleInfo = 'errorLens.toggleInfo',
-    ToggleHint = 'errorLens.toggleHint',
-    ToggleInlineMessage = 'errorLens.toggleInlineMessage',
-    /** {@link toggleWorkspaceCommand} */
-    ToggleWorkspace = 'errorlens.toggleWorkspace',
-    /** {@link copyProblemMessageCommand} */
-    CopyProblemMessage = 'errorLens.copyProblemMessage',
-    /** {@link copyProblemCodeCommand} */
-    CopyProblemCode = 'errorLens.copyProblemCode',
-    /** {@link selectProblem} */
-    SelectProblem = 'errorLens.selectProblem',
-    /** {@link findLinterRuleDefinitionCommand} */
-    FindLinterRuleDefinition = 'errorLens.findLinterRuleDefinition',
-    /** {@link searchForProblemCommand} */
-    SearchForProblem = 'errorLens.searchForProblem',
-    /** {@link disableLineCommand} */
-    DisableLine = 'errorLens.disableLine',
-    // ──── Internal ──────────────────────────────────────────────
-    /** {@link statusBarCommand} */
-    StatusBarCommand = 'errorLens.statusBarCommand',
-    /** {@link revealLineCommand} */
-    RevealLine = 'errorLens.revealLine',
-    /** {@link excludeProblemCommand} */
-    ExcludeProblem = 'errorLens.excludeProblem',
+	// ──── User facing ───────────────────────────────────────────
+	Toggle = 'errorLens.toggle',
+	ToggleError = 'errorLens.toggleError',
+	ToggleWarning = 'errorLens.toggleWarning',
+	ToggleInfo = 'errorLens.toggleInfo',
+	ToggleHint = 'errorLens.toggleHint',
+	ToggleInlineMessage = 'errorLens.toggleInlineMessage',
+	/** {@link toggleWorkspaceCommand} */
+	ToggleWorkspace = 'errorlens.toggleWorkspace',
+	/** {@link copyProblemMessageCommand} */
+	CopyProblemMessage = 'errorLens.copyProblemMessage',
+	/** {@link copyProblemCodeCommand} */
+	CopyProblemCode = 'errorLens.copyProblemCode',
+	/** {@link selectProblem} */
+	SelectProblem = 'errorLens.selectProblem',
+	/** {@link findLinterRuleDefinitionCommand} */
+	FindLinterRuleDefinition = 'errorLens.findLinterRuleDefinition',
+	/** {@link searchForProblemCommand} */
+	SearchForProblem = 'errorLens.searchForProblem',
+	/** {@link disableLineCommand} */
+	DisableLine = 'errorLens.disableLine',
+	// ──── Internal ──────────────────────────────────────────────
+	/** {@link statusBarCommand} */
+	StatusBarCommand = 'errorLens.statusBarCommand',
+	/** {@link revealLineCommand} */
+	RevealLine = 'errorLens.revealLine',
+	/** {@link excludeProblemCommand} */
+	ExcludeProblem = 'errorLens.excludeProblem',
 }
 
 /**
  * Register all commands contributed by this extension.
  */
 export function registerAllCommands(context: ExtensionContext): void {
-    // ────────────────────────────────────────────────────────────
-    // ──── Global commands ───────────────────────────────────────
-    // ────────────────────────────────────────────────────────────
-    context.subscriptions.push(
-        commands.registerCommand(CommandId.Toggle, () => {
-            vscodeUtils.updateGlobalSetting('errorLens.enabled', !$config.enabled)
-        }),
-    )
-    context.subscriptions.push(
-        commands.registerCommand(CommandId.ToggleError, () => {
-            toggleEnabledLevels('error', $config.enabledDiagnosticLevels)
-        }),
-    )
-    context.subscriptions.push(
-        commands.registerCommand(CommandId.ToggleWarning, () => {
-            toggleEnabledLevels('warning', $config.enabledDiagnosticLevels)
-        }),
-    )
-    context.subscriptions.push(
-        commands.registerCommand(CommandId.ToggleInfo, () => {
-            toggleEnabledLevels('info', $config.enabledDiagnosticLevels)
-        }),
-    )
-    context.subscriptions.push(
-        commands.registerCommand(CommandId.ToggleHint, () => {
-            toggleEnabledLevels('hint', $config.enabledDiagnosticLevels)
-        }),
-    )
-    context.subscriptions.push(
-        commands.registerCommand(CommandId.ToggleInlineMessage, () => {
-            vscodeUtils.toggleGlobalBooleanSetting('errorLens.messageEnabled')
-        }),
-    )
-    context.subscriptions.push(commands.registerCommand(CommandId.ToggleWorkspace, toggleWorkspaceCommand))
-    context.subscriptions.push(commands.registerCommand(CommandId.RevealLine, revealLineCommand))
-    context.subscriptions.push(commands.registerCommand(CommandId.FindLinterRuleDefinition, findLinterRuleDefinitionCommand))
-    context.subscriptions.push(commands.registerCommand(CommandId.ExcludeProblem, excludeProblemCommand))
-    context.subscriptions.push(commands.registerCommand(CommandId.CopyProblemCode, copyProblemCodeCommand))
-    context.subscriptions.push(commands.registerCommand(CommandId.SearchForProblem, searchForProblemCommand))
-    context.subscriptions.push(commands.registerCommand(CommandId.DisableLine, disableLineCommand))
-    // ────────────────────────────────────────────────────────────
-    // ──── Text Editor commands ──────────────────────────────────
-    // ────────────────────────────────────────────────────────────
-    context.subscriptions.push(commands.registerTextEditorCommand(CommandId.SelectProblem, selectProblem))
-    context.subscriptions.push(commands.registerTextEditorCommand(CommandId.CopyProblemMessage, copyProblemMessageCommand))
-    context.subscriptions.push(commands.registerTextEditorCommand(CommandId.StatusBarCommand, statusBarCommand))
+	// ────────────────────────────────────────────────────────────
+	// ──── Global commands ───────────────────────────────────────
+	// ────────────────────────────────────────────────────────────
+	context.subscriptions.push(
+		commands.registerCommand(CommandId.Toggle, () => {
+			vscodeUtils.updateGlobalSetting('errorLens.enabled', !$config.enabled);
+		}),
+	);
+	context.subscriptions.push(
+		commands.registerCommand(CommandId.ToggleError, () => {
+			toggleEnabledLevels('error', $config.enabledDiagnosticLevels);
+		}),
+	);
+	context.subscriptions.push(
+		commands.registerCommand(CommandId.ToggleWarning, () => {
+			toggleEnabledLevels('warning', $config.enabledDiagnosticLevels);
+		}),
+	);
+	context.subscriptions.push(
+		commands.registerCommand(CommandId.ToggleInfo, () => {
+			toggleEnabledLevels('info', $config.enabledDiagnosticLevels);
+		}),
+	);
+	context.subscriptions.push(
+		commands.registerCommand(CommandId.ToggleHint, () => {
+			toggleEnabledLevels('hint', $config.enabledDiagnosticLevels);
+		}),
+	);
+	context.subscriptions.push(
+		commands.registerCommand(CommandId.ToggleInlineMessage, () => {
+			vscodeUtils.toggleGlobalBooleanSetting('errorLens.messageEnabled');
+		}),
+	);
+	context.subscriptions.push(commands.registerCommand(CommandId.ToggleWorkspace, toggleWorkspaceCommand));
+	context.subscriptions.push(commands.registerCommand(CommandId.RevealLine, revealLineCommand));
+	context.subscriptions.push(commands.registerCommand(CommandId.FindLinterRuleDefinition, findLinterRuleDefinitionCommand));
+	context.subscriptions.push(commands.registerCommand(CommandId.ExcludeProblem, excludeProblemCommand));
+	context.subscriptions.push(commands.registerCommand(CommandId.CopyProblemCode, copyProblemCodeCommand));
+	context.subscriptions.push(commands.registerCommand(CommandId.SearchForProblem, searchForProblemCommand));
+	context.subscriptions.push(commands.registerCommand(CommandId.DisableLine, disableLineCommand));
+	// ────────────────────────────────────────────────────────────
+	// ──── Text Editor commands ──────────────────────────────────
+	// ────────────────────────────────────────────────────────────
+	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.SelectProblem, selectProblem));
+	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.CopyProblemMessage, copyProblemMessageCommand));
+	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.StatusBarCommand, statusBarCommand));
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -31,7 +31,7 @@ export const enum CommandId {
 	/** {@link copyProblemCodeCommand} */
 	CopyProblemCode = 'errorLens.copyProblemCode',
 	/** {@link selectProblem} */
-	SelectProblem = 'errorLens.selectProblem',
+	SelectProblem = 'SelectProblem',
 	/** {@link findLinterRuleDefinitionCommand} */
 	FindLinterRuleDefinition = 'errorLens.findLinterRuleDefinition',
 	/** {@link searchForProblemCommand} */
@@ -54,36 +54,24 @@ export function registerAllCommands(context: ExtensionContext): void {
 	// ────────────────────────────────────────────────────────────
 	// ──── Global commands ───────────────────────────────────────
 	// ────────────────────────────────────────────────────────────
-	context.subscriptions.push(
-		commands.registerCommand(CommandId.Toggle, () => {
-			vscodeUtils.updateGlobalSetting('errorLens.enabled', !$config.enabled);
-		}),
-	);
-	context.subscriptions.push(
-		commands.registerCommand(CommandId.ToggleError, () => {
-			toggleEnabledLevels('error', $config.enabledDiagnosticLevels);
-		}),
-	);
-	context.subscriptions.push(
-		commands.registerCommand(CommandId.ToggleWarning, () => {
-			toggleEnabledLevels('warning', $config.enabledDiagnosticLevels);
-		}),
-	);
-	context.subscriptions.push(
-		commands.registerCommand(CommandId.ToggleInfo, () => {
-			toggleEnabledLevels('info', $config.enabledDiagnosticLevels);
-		}),
-	);
-	context.subscriptions.push(
-		commands.registerCommand(CommandId.ToggleHint, () => {
-			toggleEnabledLevels('hint', $config.enabledDiagnosticLevels);
-		}),
-	);
-	context.subscriptions.push(
-		commands.registerCommand(CommandId.ToggleInlineMessage, () => {
-			vscodeUtils.toggleGlobalBooleanSetting('errorLens.messageEnabled');
-		}),
-	);
+	context.subscriptions.push(commands.registerCommand(CommandId.Toggle, () => {
+		vscodeUtils.updateGlobalSetting('errorLens.enabled', !$config.enabled);
+	}));
+	context.subscriptions.push(commands.registerCommand(CommandId.ToggleError, () => {
+		toggleEnabledLevels('error', $config.enabledDiagnosticLevels);
+	}));
+	context.subscriptions.push(commands.registerCommand(CommandId.ToggleWarning, () => {
+		toggleEnabledLevels('warning', $config.enabledDiagnosticLevels);
+	}));
+	context.subscriptions.push(commands.registerCommand(CommandId.ToggleInfo, () => {
+		toggleEnabledLevels('info', $config.enabledDiagnosticLevels);
+	}));
+	context.subscriptions.push(commands.registerCommand(CommandId.ToggleHint, () => {
+		toggleEnabledLevels('hint', $config.enabledDiagnosticLevels);
+	}));
+	context.subscriptions.push(commands.registerCommand(CommandId.ToggleInlineMessage, () => {
+		vscodeUtils.toggleGlobalBooleanSetting('errorLens.messageEnabled');
+	}));
 	context.subscriptions.push(commands.registerCommand(CommandId.ToggleWorkspace, toggleWorkspaceCommand));
 	context.subscriptions.push(commands.registerCommand(CommandId.RevealLine, revealLineCommand));
 	context.subscriptions.push(commands.registerCommand(CommandId.FindLinterRuleDefinition, findLinterRuleDefinitionCommand));
@@ -98,3 +86,4 @@ export function registerAllCommands(context: ExtensionContext): void {
 	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.CopyProblemMessage, copyProblemMessageCommand));
 	context.subscriptions.push(commands.registerTextEditorCommand(CommandId.StatusBarCommand, statusBarCommand));
 }
+

--- a/src/commands/selectProblem.ts
+++ b/src/commands/selectProblem.ts
@@ -1,0 +1,16 @@
+import { extUtils } from 'src/utils/extUtils';
+import { Selection, type TextEditor } from 'vscode';
+
+/**
+ * Can be used from Command Palette (arg = undefined) or from hover (arg = {code: string | undefined})
+ */
+export function selectProblem(editor: TextEditor): void {
+	const diagnosticAtActiveLineNumber = extUtils.getDiagnosticAtLine(editor.document.uri, editor.selection.active.line);
+
+	if (!diagnosticAtActiveLineNumber) {
+		return;
+	}
+
+	const { range } = diagnosticAtActiveLineNumber;
+	editor.selection = new Selection(range.start, range.end);
+}


### PR DESCRIPTION
There are already commands to work with current diagnostic in line, so I decided to propose another one! This is really useful in some scenarios, for example when you want to remove problematic code with shortcut:

```json
{
  "a": 5 // comments in json are reported as errors and can be easily removed by selecting them
}
```

And some errors are just easier to fix with selection:
```ts
type A = () => true | () => false
//                   ~~~~~~~~~~~~ [ts] Function type notation must be parenthesized when used in a union type.
// Here it would be enough to select the error and then press (
```

